### PR TITLE
タバコ登録DB、モデル

### DIFF
--- a/app/models/cigarette.rb
+++ b/app/models/cigarette.rb
@@ -1,0 +1,37 @@
+class Cigarette < ApplicationRecord
+  belongs_to :user
+
+  validates :brand, presence: true
+  validates :quantity_per_pack, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :price_per_pack, presence: true, numericality: { only_integer: true, greater_than: 0 }
+
+  validate :limit_cigarette_count, on: :create
+  validate :validate_price_per_cigarette
+
+  before_validation :calculate_price_per_cigarette
+
+  private
+
+  def calculate_price_per_cigarette
+    return if price_per_pack.blank? || quantity_per_pack.blank?
+    @calculated_price = (price_per_pack.to_f / quantity_per_pack)
+  end
+
+  def validate_price_per_cigarette
+    return if @calculated_price.nil?
+
+    if @calculated_price < 0
+      errors.add(:base, "計算結果がマイナスになります。正しい値を入力してください。")
+    elsif @calculated_price >= 100
+      errors.add(:base, "計算結果が100円以上になります。正しい値を入力してください。")
+    else
+      self.price_per_cigarette = @calculated_price.round(2)
+    end
+  end
+
+  def limit_cigarette_count
+    if user.cigarettes.count >= 2
+      errors.add(:base, "最大2種類のタバコしか登録できません")
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  has_many :cigarettes, dependent: :destroy
+
   enum smoking_status: { smoker: 0, non_smoker: 1 }
 
   validates :password, length: { minimum: 8 }, if: -> { new_record? || changes[:crypted_password] }

--- a/db/migrate/20240826130329_create_cigarettes.rb
+++ b/db/migrate/20240826130329_create_cigarettes.rb
@@ -1,0 +1,13 @@
+class CreateCigarettes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :cigarettes do |t|
+      t.string :brand, null: false
+      t.integer :quantity_per_pack, null: false
+      t.integer :price_per_pack, null: false
+      t.decimal :price_per_cigarette, precision: 4, scale: 2, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_25_080818) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_26_130329) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "cigarettes", force: :cascade do |t|
+    t.string "brand", null: false
+    t.integer "quantity_per_pack", null: false
+    t.integer "price_per_pack", null: false
+    t.decimal "price_per_cigarette", precision: 4, scale: 2, null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_cigarettes_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -25,4 +36,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_25_080818) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "cigarettes", "users"
 end


### PR DESCRIPTION
### タバコ登録DB、モデル作成

**attribute**

- brand-銘柄(string)
- quantity_per_pack - 何本入りか(int)
- price_per_pack - 一箱の値段(int)
- price_per_cigarette - タバコ１本分の値段(decimal)

**制約**

- referencesを使いuserテーブルをFKとしてもつこと
- brand - nullを許容しない
- quantity_per_pack - nullを許容しない
- price_per_pack - nullを許容しない
- price_per_cigarette - nullを許容しない,99.99までしか受け付けない

**モデル**

1. タバコ情報の基本属性
   - ブランド名 (brand)
   - 1箱あたりの本数 (quantity_per_pack)
   - 1箱あたりの価格 (price_per_pack)
   - 1本あたりの価格 (price_per_cigarette) - 自動計算

2. ユーザーごとの登録制限
   - 各ユーザーは最大2種類のタバコのみ登録可能

3. 価格計算ロジック
   - 1本あたりの価格を自動計算
   - 計算結果が0円未満または100円以上の場合はエラーを表示

4. バリデーション
   - 各入力フィールドの存在チェックと数値バリデーション
   - カスタムバリデーションによる計算結果のチェック
