### PR TITLE
禁煙DB、モデル作成

### DIFF
--- a/app/models/quit_smoking_record.rb
+++ b/app/models/quit_smoking_record.rb
@@ -1,0 +1,21 @@
+class QuitSmokingRecord < ApplicationRecord
+  belongs_to :user
+
+  validates :start_date, presence: true
+  validate :end_date_after_start_date, if: :end_date
+
+  scope :active, -> { where(end_date: nil) }
+  scope :completed, -> { where.not(end_date: nil) }
+
+  def active?
+    end_date.nil?
+  end
+
+  private
+
+  def end_date_after_start_date
+    if end_date.present? && end_date <= start_date
+      errors.add(:end_date, "must be after the start date")
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
 
   has_many :cigarettes, dependent: :destroy
   has_many :smoking_records, dependent: :destroy
+  has_many :quit_smoking_records, dependent: :destroy
 
   enum smoking_status: { smoker: 0, non_smoker: 1 }
 

--- a/db/migrate/20240911121915_create_quit_smoking_records.rb
+++ b/db/migrate/20240911121915_create_quit_smoking_records.rb
@@ -1,0 +1,11 @@
+class CreateQuitSmokingRecords < ActiveRecord::Migration[7.1]
+  def change
+    create_table :quit_smoking_records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :start_date, null: false
+      t.date :end_date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_02_132328) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_11_121915) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_02_132328) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_cigarettes_on_user_id"
+  end
+
+  create_table "quit_smoking_records", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "start_date", null: false
+    t.date "end_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_quit_smoking_records_on_user_id"
   end
 
   create_table "smoking_records", force: :cascade do |t|
@@ -49,6 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_02_132328) do
   end
 
   add_foreign_key "cigarettes", "users"
+  add_foreign_key "quit_smoking_records", "users"
   add_foreign_key "smoking_records", "cigarettes"
   add_foreign_key "smoking_records", "users"
 end


### PR DESCRIPTION
### 禁煙DB,モデル作成

**quit_smoking_recordsテーブルの作成**

- userをFKとして持っている
- start_date（禁煙開始日）　　未入力を防ぐ
- end_date（禁煙終了日）　　 

**quit_smoking_recordモデルファイル**

1. カスタムバリデーションの実施（end_date）
  - 未入力の場合はバリデーションをスキップし、存在する場合は必ずstart_dateより後に設定
される。

2. スコープ **active** と **completed** を定義
  - active -  アクティブな禁煙記録を取得
  - completed - 完了した禁煙記録の取得


  　　　　　　　　　　　　　 



