### PR TITLE
禁煙記録に使う計算ロジック、コントローラーの作成

### DIFF
--- a/app/controllers/non_smoker/quit_smoking_records_controller.rb
+++ b/app/controllers/non_smoker/quit_smoking_records_controller.rb
@@ -1,0 +1,65 @@
+class NonSmoker::QuitSmokingRecordsController < ApplicationController
+  before_action :require_login
+  before_action :set_quit_smoking_record, only: [:update]
+
+  def index
+    # 現在進行中の禁煙試行を取得
+    @current_quit_attempt = current_user.quit_smoking_records.active.first
+    # すべての禁煙記録を日付順に取得
+    @quit_smoking_records = current_user.quit_smoking_records.order(start_date: :desc)
+    # 1日あたりの潜在的な節約額を計算
+    @daily_potential_savings = current_user.calculate_daily_potential_savings
+    # 総禁煙日数を計算
+    @total_quit_days = calculate_total_quit_days
+    # 総節約額を計算
+    @total_savings = calculate_total_savings
+  end
+
+  def create
+    ActiveRecord::Base.transaction do
+      @quit_smoking_record = current_user.quit_smoking_records.build(start_date: Date.today)
+      @quit_smoking_record.save!
+      update_user_status(:non_smoker)
+    end
+    redirect_to quit_smoking_records_path, notice: '禁煙を開始しました。頑張りましょう！'
+  rescue ActiveRecord::RecordInvalid
+    redirect_back(fallback_location: smoker_smoking_records_path, alert: '禁煙の開始に失敗しました。')
+  end
+
+  def update
+    ActiveRecord::Base.transaction do
+      @quit_smoking_record.update!(end_date: Date.today)
+      update_user_status(:smoker)
+    end
+    redirect_to quit_smoking_records_path, notice: '禁煙記録を更新しました。次の挑戦に向けて準備しましょう。'
+  rescue ActiveRecord::RecordInvalid
+    redirect_back(fallback_location: smoker_quit_smoking_records_path, alert: '禁煙の開始に失敗しました。')
+  end
+
+  private
+
+  # 特定の禁煙記録を取得するメソッド
+  def set_quit_smoking_record
+    @quit_smoking_record = current_user.quit_smoking_records.find(params[:id])
+  end
+
+  # ユーザーの喫煙状態を更新するメソッド
+  def update_user_status(status)
+    current_user.update!(smoking_status: status)
+  end
+
+  # 総禁煙日数を計算するメソッド
+  def calculate_total_quit_days
+    current_user.quit_smoking_records.sum do |record|
+      (record.end_date || Date.today) - record.start_date
+    end.to_i
+  end
+
+  # 総節約額を計算するメソッド
+  def calculate_total_savings
+    current_user.quit_smoking_records.sum do |record|
+      days = ((record.end_date || Date.today) - record.start_date).to_i
+      days * @daily_potential_savings
+    end
+  end
+end

--- a/app/controllers/smoker/smoking_records_controller.rb
+++ b/app/controllers/smoker/smoking_records_controller.rb
@@ -1,13 +1,10 @@
 class Smoker::SmokingRecordsController < ApplicationController
   before_action :require_login
-  before_action :set_smoking_records, only: [:index, :create]
-  before_action :set_statistics, only: [:index, :create]
   before_action :set_smoking_record, only: [:destroy]
+  before_action :set_common_data, only: [:index, :create]
 
   def index
-    @new_smoking_record = SmokingRecord.build
-    @cigarettes = Cigarette.all
-    set_calendar_data
+    @new_smoking_record = SmokingRecord.new
     @smoking_records = current_user.smoking_records.today.order(smoked_at: :desc).page(params[:page]).per(10)
   end
 
@@ -16,10 +13,8 @@ class Smoker::SmokingRecordsController < ApplicationController
     if @smoking_record.save
       redirect_to smoker_smoking_records_path, notice: '喫煙記録が追加されました。'
     else
-      @smoking_records = current_user.smoking_records.today.order(smoked_at: :desc).page(params[:page]).per(10)
       @new_smoking_record = @smoking_record
-      @cigarettes = Cigarette.all
-      set_calendar_data
+      @smoking_records = current_user.smoking_records.today.order(smoked_at: :desc).page(params[:page]).per(10)
       render :index, status: :unprocessable_entity
     end
   end
@@ -34,8 +29,11 @@ class Smoker::SmokingRecordsController < ApplicationController
 
   private
 
-  def set_smoking_records
+  def set_common_data
     @smoking_records = current_user.smoking_records.order(smoked_at: :desc).limit(10)
+    @cigarettes = current_user.cigarettes
+    set_statistics
+    set_calendar_data
   end
 
   def set_statistics

--- a/app/models/quit_smoking_record.rb
+++ b/app/models/quit_smoking_record.rb
@@ -11,6 +11,10 @@ class QuitSmokingRecord < ApplicationRecord
     end_date.nil?
   end
 
+  def duration
+    (end_date || Date.today) - start_date
+  end
+
   private
 
   def end_date_after_start_date

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,24 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 10 }
   validates :email, presence: true, uniqueness: true
+
+  def calculate_daily_potential_savings
+    return 0 if smoking_records.empty?
+    total_spent = smoking_records.sum(:price_per_cigarette)
+    total_days = (smoking_records.maximum(:smoked_at).to_date - smoking_records.minimum(:smoked_at).to_date).to_i + 1
+    (total_spent / total_days).round(2)
+  end
+
+  def average_daily_cigarettes
+    return 0 if smoking_records.empty?
+    total_days = (smoking_records.maximum(:smoked_at).to_date - smoking_records.minimum(:smoked_at).to_date).to_i + 1
+    (smoking_records.count.to_f / total_days).round(2)
+  end
+
+  def analyze_danger_hours
+    records = smoking_records
+    hours = records.group_by { |r| r.smoked_at.hour }
+    danger_hours = hours.max_by(3) { |_, records| records.count }
+    danger_hours.map { |hour, _| hour }.sort
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   namespace :smoker do
     resources :cigarettes, only: [:index, :create, :edit, :update]
     resources :smoking_records, only: [:index, :create, :destroy]
+    resources :quit_smoking_records, only: [:index, :create, :update]
   end
 
   get 'login', to: 'user_sessions#new', as: :login


### PR DESCRIPTION
### 禁煙記録コントローラー、計算ロジックの作成

**controller**

1. index
  - 現在進行中の禁煙試行を取得
  - すべての禁煙記録を日付順に取得
  - 1日あたりの潜在的な節約額を取得
  - 総禁煙日数を取得
  - 総節約金額を取得

2. create
  - 新しい禁煙記録を作成し、ユーザーの状態を非喫煙者に更新
  - 成功した場合、禁煙一覧ページへ遷移
  - 失敗した場合現状のページを維持

3. update
  - 禁煙記録を終了し、ユーザーの状態を喫煙者に戻す
  - 成功した場合、喫煙一覧ページへ遷移
  - 失敗した場合現状のページを維持


**model**

1. user
  - 1日あたりの潜在的な節約額を計算するメソッド
  - 1日あたりの平均喫煙本数を計算するメソッド
  - 喫煙が多い危険な時間帯を分析するメソッド

