### PR TITLE
ヘッダーに禁煙を始めるボタンを追加

### DIFF
--- a/app/controllers/non_smoker/quit_smoking_records_controller.rb
+++ b/app/controllers/non_smoker/quit_smoking_records_controller.rb
@@ -28,7 +28,7 @@ class NonSmoker::QuitSmokingRecordsController < ApplicationController
   def update
     if @quit_smoking_record.update(end_date: Time.current)
       current_user.update(smoking_status: :smoker)
-      redirect_to non_smoker_quit_smoking_records_path, notice: '禁煙記録を更新しました。次の挑戦に向けて準備しましょう。'
+      redirect_to smoker_smoking_records_path, notice: '禁煙を終了します。お疲れ様でした！'
     else
       redirect_to non_smoker_quit_smoking_records_path, alert: '禁煙記録の更新に失敗しました。'
     end

--- a/app/views/non_smoker/quit_smoking_records/index.html.erb
+++ b/app/views/non_smoker/quit_smoking_records/index.html.erb
@@ -1,7 +1,7 @@
 <div class="ml-48 pt-16 bg-darkBackground">
   <div class="container mx-auto px-4 py-8 max-w-6xl">
     <h1 class="text-2xl font-bold mb-6 text-white flex items-center">
-      禁煙管理
+      禁煙記録
     </h1>
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -44,7 +44,7 @@
         </div>
         <div class="bg-cardBackground p-4 rounded-lg shadow-lg">
           <h3 class="text-base font-semibold mb-2 text-white flex items-center">
-            <%= inline_svg_tag 'icons-bar-chart.svg', class: 'w-5 h-5 mr-2' %>
+            <%= inline_svg_tag 'icons-chart.svg', class: 'w-5 h-5 mr-2' %>
             1日の節約可能額
           </h3>
           <p class="text-lg font-bold text-green-500"><%= number_to_currency(@daily_potential_savings, unit: '¥', precision: 0) %></p>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -7,7 +7,25 @@
       </div>
     <% end %>
   </div>
-  <div class="flex items-center mr-4">
-    <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete }, class: 'text-sm bg-customGreen text-white px-4 py-2 rounded hover:text-darkBackground' %>
+  <div class="flex items-center mr-4 space-x-4">
+    <% if current_user.smoker? %>
+      <label for="quit-smoking-modal" class="btn btn-primary">禁煙する</label>
+    <% end %>
+    <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete }, class: 'btn btn-ghost bg-customGreen' %>
   </div>
 </header>
+
+<!-- 禁煙開始モーダル -->
+<input type="checkbox" id="quit-smoking-modal" class="modal-toggle" />
+<div class="modal">
+  <div class="modal-box bg-gradient-to-br from-customForm to-cardBackground text-labelColor">
+    <h3 class="font-light text-2xl mb-6">禁煙を始めますか？</h3>
+    <p class="mb-6">禁煙を開始すると、あなたの健康と財布にとってプラスになります。今すぐ始めましょう！</p>
+    <%= form_with(url: non_smoker_quit_smoking_records_path, local: true, method: :post) do |f| %>
+      <div class="mt-6 flex justify-end space-x-3">
+        <label for="quit-smoking-modal" class="btn btn-ghost">キャンセル</label>
+        <%= f.submit '禁煙を開始', class: 'btn btn-primary' %>
+      </div>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
### ヘッダーに禁煙ボタンを追加

- 禁煙を始めるボタンがあること
- モーダルが表示されること
- モーダルを承認すると正しく喫煙記録がつけられ、userがnon_snokerの状態に移行すること
- 正しくページが遷移すること