### PR TITLE
過去の禁煙金額が喫煙記録をつけることによって値が変更されないように修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,11 +31,19 @@ module ApplicationHelper
 
   # サイドバーのアクティブリンクを判定
   def calculate_savings(seconds, daily_potential_savings)
-    (daily_potential_savings * seconds / 86400.0).round(0)
+    (daily_potential_savings * seconds / 1.day).round(0)
   end
 
   def total_savings
-    current_user.quit_smoking_records.sum { |record| record.duration * current_user.calculate_daily_potential_savings / 1.day }
+    completed_savings = current_user.quit_smoking_records.completed.sum(:money_saved)
+    current_quit_attempt = current_user.quit_smoking_records.active.first
+    current_savings = if current_quit_attempt
+                        daily_savings = current_user.calculate_daily_potential_savings
+                        calculate_savings(current_quit_attempt.duration, daily_savings)
+                      else
+                        0
+                      end
+    completed_savings + current_savings
   rescue
     0
   end


### PR DESCRIPTION
### ロジックの修正

**問題点**

現状完了した禁煙期間の節約金額が、喫煙することによって変わってしまうこと。

**修正**

1. update

- 禁煙記録が終了する時点で、その時の日次節約額を基に最終的な節約金額を計算し、記録。これにより、一度完了した禁煙記録の節約金額を固定

2. calculate_total_savings

- 完了した禁煙記録の節約金額は money_saved フィールドから直接取得し、現在進行中の禁煙試行の節約金額のみを動的に計算
