### PR TITLE
喫煙記録ログにタバコが編集されても過去のブランド名を反映

### DIFF
--- a/app/models/smoking_record.rb
+++ b/app/models/smoking_record.rb
@@ -5,6 +5,7 @@ class SmokingRecord < ApplicationRecord
   validates :smoked_at, presence: true
 
   before_validation :set_price_per_cigarette
+  before_validation :set_brand_name
   before_validation :set_smoked_at
 
   scope :today, -> { where(smoked_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day) }
@@ -29,6 +30,10 @@ class SmokingRecord < ApplicationRecord
 
   def set_price_per_cigarette
     self.price_per_cigarette = cigarette.price_per_cigarette if cigarette
+  end
+
+  def set_brand_name
+    self.brand_name = cigarette.brand if cigarette
   end
 
   def set_smoked_at

--- a/app/views/smoker/smoking_records/index.html.erb
+++ b/app/views/smoker/smoking_records/index.html.erb
@@ -106,7 +106,7 @@
           <li class="bg-itemBackground p-3 rounded-lg shadow transition duration-300 hover:bg-base-100">
             <div class="grid grid-cols-12 items-center gap-2">
               <span class="text-base-content opacity-70 col-span-5 truncate"><%= log.smoked_at.strftime("%Y/%m/%d %H:%M") %></span>
-              <span class="font-medium text-base-content col-span-3 truncate"><%= log.cigarette.brand %></span>
+              <span class="font-medium text-base-content col-span-3 truncate"><%= log.brand_name %></span>
               <span class="text-accent col-span-3 pl-4"><%= number_to_currency(log.price_per_cigarette) %></span>
               <div class="col-span-1 flex justify-end">
                 <%= button_to smoker_smoking_record_path(log), method: :delete, data: { turbo_confirm: "本当にこの記録を削除しますか？" }, class: "btn btn-ghost btn-xs" do %>

--- a/db/migrate/20240925112920_add_brand_name_to_smoking_records.rb
+++ b/db/migrate/20240925112920_add_brand_name_to_smoking_records.rb
@@ -1,0 +1,5 @@
+class AddBrandNameToSmokingRecords < ActiveRecord::Migration[7.1]
+  def change
+    add_column :smoking_records, :brand_name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_24_135504) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_25_112920) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,6 +41,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_24_135504) do
     t.datetime "smoked_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "brand_name", null: false
     t.index ["cigarette_id"], name: "index_smoking_records_on_cigarette_id"
     t.index ["user_id", "smoked_at"], name: "index_smoking_records_on_user_id_and_smoked_at"
     t.index ["user_id"], name: "index_smoking_records_on_user_id"


### PR DESCRIPTION
### タバコが編集されてもログの記録のブランド名が変わらないように変更

- brand_nameをsmoking_recordsテーブルに追加
- 対応するcigarette.brandが入るようにする
- brand_nameの値をログで表示させる