### PR TITLE
シンプルカレンダーの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'inline_svg'
 # ページネーション
 gem 'kaminari'
 
+gem 'simple_calendar', '~> 2.4'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.3", ">= 7.1.3.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simple_calendar (2.4.3)
+      rails (>= 3.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -308,6 +310,7 @@ DEPENDENCIES
   rails (~> 7.1.3, >= 7.1.3.4)
   rails-i18n
   selenium-webdriver
+  simple_calendar (~> 2.4)
   sorcery
   sprockets-rails
   stimulus-rails

--- a/app/models/quit_smoking_record.rb
+++ b/app/models/quit_smoking_record.rb
@@ -19,7 +19,6 @@ class QuitSmokingRecord < ApplicationRecord
     end_date ? (end_date - start_date) : (Time.current - start_date)
   end
 
-  # 新しく追加されたメソッド
   def calculate_savings
     daily_savings = user.calculate_daily_potential_savings
     (daily_savings * duration / 1.day).round(0)

--- a/app/models/smoking_record.rb
+++ b/app/models/smoking_record.rb
@@ -11,8 +11,6 @@ class SmokingRecord < ApplicationRecord
   before_validation :set_smoked_at
 
   scope :today, -> { where(smoked_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day) }
-  scope :in_date_range, ->(start_date, end_date) { where(smoked_at: start_date.beginning_of_day..end_date.end_of_day) }
-  scope :grouped_by_date, -> { group('DATE(smoked_at)') }
 
   def self.total_amount
     sum(:price_per_cigarette)
@@ -30,13 +28,8 @@ class SmokingRecord < ApplicationRecord
     today.count
   end
 
-  def self.calendar_data(start_date, end_date)
-    in_date_range(start_date, end_date)
-      .grouped_by_date
-      .select('DATE(smoked_at) as date, COUNT(*) as count, SUM(price_per_cigarette) as amount')
-      .each_with_object({}) do |record, hash|
-        hash[record.date.to_date] = { count: record.count, amount: record.amount }
-      end
+  def start_time
+    smoked_at
   end
 
   private

--- a/app/views/simple_calendar/_calendar.html.erb
+++ b/app/views/simple_calendar/_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+    <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
+    <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <%= content_tag :tr, class: calendar.tr_classes_for(week) do %>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% if defined?(Haml) && respond_to?(:block_is_haml?) && block_is_haml?(passed_block) %>
+                <% capture_haml(day, sorted_events.fetch(day, []), &passed_block) %>
+              <% else %>
+                <% passed_block.call day, sorted_events.fetch(day, []) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,42 @@
+<div class="bg-cardBackground rounded-lg p-4 shadow-lg mb-6">
+  <div class="flex justify-between items-center mb-4">
+    <h2 class="text-xl font-bold flex items-center text-white">
+      <%= inline_svg_tag 'icons-calendar.svg', class: "w-5 h-5 mr-2" %>
+      喫煙カレンダー
+    </h2>
+    <div class="flex space-x-2">
+      <%= link_to t('simple_calendar.previous', default: '前月'), calendar.url_for_previous_view, class: 'btn btn-outline btn-success btn-sm' %>
+      <span class="text-white text-lg"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
+      <%= link_to t('simple_calendar.next', default: '次月'), calendar.url_for_next_view, class: 'btn btn-outline btn-success btn-sm' %>
+    </div>
+  </div>
+
+  <table class="w-full border-collapse bg-darkBackground table-fixed">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |date| %>
+          <th class="text-center font-bold text-labelColor text-xs p-1 border border-borderColor2 w-1/7"><%= t('date.abbr_day_names')[date.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+    <% date_range.each_slice(7) do |week| %>
+      <tr>
+        <% week.each do |date| %>
+          <%= content_tag :td, class: "border border-borderColor2 p-1 h-16 w-1/7 overflow-hidden #{date.month == start_date.month ? '' : 'opacity-30'}" do %>
+            <div class="h-full overflow-y-auto <%= date == Date.current ? 'bg-itemBackground' : '' %>">
+              <div class="text-xs font-bold <%= date == Date.current ? 'text-white' : 'text-labelColor' %>"><%= date.day %></div>
+              <% if defined?(Haml) && respond_to?(:block_is_haml?) && block_is_haml?(passed_block) %>
+                <% capture_haml(date, sorted_events.fetch(date, []), &passed_block) %>
+              <% else %>
+                <% passed_block.call date, sorted_events.fetch(date, []) %>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,0 +1,37 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+    <% if calendar.number_of_weeks == 1 %>
+      <span class="calendar-title"><%= t('simple_calendar.week', default: 'Week') %> <%= calendar.week_number %></span>
+    <% else %>
+      <span class="calendar-title"><%= t('simple_calendar.week', default: 'Week') %> <%= calendar.week_number %> - <%= calendar.end_week %></span>
+    <% end %>
+    <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% if defined?(Haml) && respond_to?(:block_is_haml?) && block_is_haml?(passed_block) %>
+                <% capture_haml(day, sorted_events.fetch(day, []), &passed_block) %>
+              <% else %>
+                <% passed_block.call day, sorted_events.fetch(day, []) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/smoker/smoking_records/_smoking_record_form.html.erb
+++ b/app/views/smoker/smoking_records/_smoking_record_form.html.erb
@@ -1,0 +1,38 @@
+<% if current_user.currently_quitting? %>
+  <div class="bg-itemBackground p-4 mb-4" role="alert">
+    <p class="font-bold text-white">現在禁煙中です</p>
+    <p class="text-gray-300">喫煙記録を追加するには、まず禁煙を終了してください。</p>
+    <%= button_to "禁煙を終了する", non_smoker_quit_smoking_record_path(current_user.quit_smoking_records.active.first), 
+                method: :patch, 
+                class: "btn btn-primary mt-2",
+                data: { turbo_confirm: '本当に禁煙を終了しますか？' } %>
+  </div>
+<% elsif @cigarettes.empty? %>
+  <p class="text-white mb-4">タバコが登録されていません。先にタバコを登録してください。</p>
+  <%= link_to "タバコを登録する", smoker_cigarettes_path, class: "btn btn-primary" %>
+<% else %>
+  <%= form_with model: [:smoker, @new_smoking_record], url: smoker_smoking_records_path, local: true do |f| %>
+    <fieldset class="mb-4">
+      <legend class="sr-only">タバコの種類を選択</legend>
+      <div class="flex flex-col sm:flex-row gap-4" role="group">
+        <% @cigarettes.each_with_index do |cigarette, index| %>
+          <div class="flex-1 relative">
+            <%= f.radio_button :cigarette_id, cigarette.id, 
+                                class: "peer absolute inset-0 opacity-0 w-full h-full cursor-pointer", 
+                                id: "cigarette_#{cigarette.id}",
+                                checked: index == 0 %>
+            <%= f.label "cigarette_#{cigarette.id}", class: "flex flex-col items-center justify-center p-4 text-gray-200 bg-gray-700 rounded-lg peer-checked:ring-2 peer-checked:ring-blue-500 peer-checked:bg-blue-600 peer-checked:text-white hover:bg-gray-600 transition-all duration-300" do %>
+              <span class="text-lg font-semibold"><%= cigarette.brand %></span>
+              <span class="text-sm opacity-70"><%= number_to_currency(cigarette.price_per_cigarette) %>/本</span>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </fieldset>
+
+    <%= f.button type: 'submit', class: "w-full btn btn-success text-white" do %>
+      <%= inline_svg_tag 'icons-smoking.svg', class: 'w-6 h-6 mr-2' %>
+      喫煙を記録
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/smoker/smoking_records/_statistics.html.erb
+++ b/app/views/smoker/smoking_records/_statistics.html.erb
@@ -1,0 +1,23 @@
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+  <% [
+    { icon: 'icons-coin.svg', title: "総合計金額", value: number_to_currency(@total_amount) },
+    { icon: 'icons-coin.svg', title: "今日の合計金額", value: number_to_currency(@today_amount) },
+    { icon: 'icons-cigarettes-pack.svg', title: "総本数", value: "#{@total_count}" },
+    { icon: 'icons-cigarettes-pack.svg', title: "今日の本数", value: "#{@today_count}" }
+  ].each do |item| %>
+    <div class="bg-cardBackground p-4 rounded-lg shadow-lg transition duration-300 hover:shadow-xl flex items-center h-24">
+      <div class="flex items-center justify-between w-full">
+        <div class="flex items-center">
+          <%= inline_svg_tag item[:icon], class: "w-6 h-6 mr-2"%>
+          <span class="text-labelColor"><%= item[:title] %></span>
+        </div>
+        <div class="text-2xl font-bold text-white flex items-center">
+          <%= item[:value] %>
+          <% if item[:title].include?("本数") %>
+            <span class="text-labelColor text-sm ml-1">本</span>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/smoker/smoking_records/index.html.erb
+++ b/app/views/smoker/smoking_records/index.html.erb
@@ -1,125 +1,36 @@
 <div class="ml-36 pt-24 bg-darkBackground min-h-screen p-6">
-  <!-- 喫煙カレンダー -->
-  <div class="bg-cardBackground rounded-lg p-6 shadow-lg mb-6">
-    <div class="flex justify-between items-center mb-4">
-      <h2 class="text-2xl font-bold flex items-center text-white">
-        <%= inline_svg_tag 'icons-calendar.svg', class: "w-6 h-6 mr-2" %>
-        喫煙カレンダー
-      </h2>
-      <div class="flex space-x-2">
-        <%= link_to '前月', smoker_smoking_records_path(start_date: @start_date.prev_month), class: 'btn btn-outline btn-success btn-sm' %>
-        <span class="text-white text-xl"><%= @start_date.strftime('%Y年%m月') %></span>
-        <%= link_to '次月', smoker_smoking_records_path(start_date: @start_date.next_month), class: 'btn btn-outline btn-success btn-sm' %>
-      </div>
-    </div>
-    <div class="grid grid-cols-7 gap-2">
-      <% ['日', '月', '火', '水', '木', '金', '土'].each do |day| %>
-        <div class="text-center font-bold text-gray-500 text-sm"><%= day %></div>
-      <% end %>
-      
-      <% (@start_date.beginning_of_month..@end_date).each do |date| %>
-        <% if date == @start_date.beginning_of_month %>
-          <% date.wday.times do %>
-            <div></div>
-          <% end %>
-        <% end %>
-        
-        <% is_today = date == Date.current %>
-        <div class="p-2 bg-itemBackground rounded-lg text-white hover:bg-opacity-80 transition-colors h-16 flex flex-col justify-between overflow-hidden <%= 'ring-2 ring-blue-500' if is_today %>">
-          <div class="text-sm font-bold <%= 'text-blue-400' if is_today %>"><%= date.day %></div>
-          <% if @calendar_data[date] %>
-            <div class="text-xs text-customGreen"><%= @calendar_data[date][:count] %>本</div>
-            <div class="text-xs text-yellow-500"><%= number_to_currency(@calendar_data[date][:amount], unit: '¥', precision: 0) %></div>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-  </div>
+  <%= month_calendar(events: @calendar_records, attribute: :smoked_at, start_date: @start_date) do |date, records| %>
+    <% if records.any? %>
+      <div class="text-xs text-customGreen"><%= records.count %>本</div>
+      <div class="text-xs text-yellow-500"><%= number_to_currency(records.sum(&:price_per_cigarette), unit: '¥', precision: 0) %></div>
+    <% end %>
+  <% end %>
 
   <!-- 喫煙記録フォーム -->
   <div class="bg-cardBackground rounded-lg p-6 mb-6 shadow-lg">
-    <% if current_user.currently_quitting? %>
-      <div class="bg-itemBackground p-4 mb-4" role="alert">
-        <p class="font-bold">現在禁煙中です</p>
-        <p>喫煙記録を追加するには、まず禁煙を終了してください。</p>
-        <%= button_to "禁煙を終了する", non_smoker_quit_smoking_record_path(current_user.quit_smoking_records.active.first), 
-                    method: :patch, 
-                    class: "btn btn-primary mt-2",
-                    data: { turbo_confirm: '本当に禁煙を終了しますか？' } %>
-      </div>
-    <% elsif @cigarettes.empty? %>
-      <p class="text-white mb-4">タバコが登録されていません。先にタバコを登録してください。</p>
-      <%= link_to "タバコを登録する", smoker_cigarettes_path, class: "btn btn-primary" %>
-    <% else %>
-      <%= form_with model: [:smoker, @new_smoking_record], url: smoker_smoking_records_path, local: true do |f| %>
-        <fieldset class="mb-4">
-          <legend class="sr-only">タバコの種類を選択</legend>
-          <div class="flex flex-col sm:flex-row gap-4" role="group">
-            <% @cigarettes.each_with_index do |cigarette, index| %>
-              <div class="flex-1 relative">
-                <%= f.radio_button :cigarette_id, cigarette.id, 
-                                    class: "peer absolute inset-0 opacity-0 w-full h-full cursor-pointer", 
-                                    id: "cigarette_#{cigarette.id}",
-                                    checked: index == 0 %>
-                <%= f.label "cigarette_#{cigarette.id}", class: "flex flex-col items-center justify-center p-4 text-gray-200 bg-gray-700 rounded-lg peer-checked:ring-2 peer-checked:ring-blue-500 peer-checked:bg-blue-600 peer-checked:text-white hover:bg-gray-600 transition-all duration-300" do %>
-                  <span class="text-lg font-semibold"><%= cigarette.brand %></span>
-                  <span class="text-sm opacity-70"><%= number_to_currency(cigarette.price_per_cigarette) %>/本</span>
-                <% end %>
-              </div>
-            <% end %>
-          </div>
-        </fieldset>
-
-        <%= f.button type: 'submit', class: "w-full btn btn-success text-white" do %>
-          <%= inline_svg_tag 'icons-smoking.svg', class: 'w-6 h-6 mr-2' %>
-          喫煙を記録
-        <% end %>
-      <% end %>
-    <% end %>
+    <%= render 'smoking_record_form' %>
   </div>
 
-  <!-- 統計情報 (変更なし) -->
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-    <% [
-      { icon: 'icons-coin.svg', title: "総合計金額", value: number_to_currency(@total_amount) },
-      { icon: 'icons-coin.svg', title: "今日の合計金額", value: number_to_currency(@today_amount) },
-      { icon: 'icons-cigarettes-pack.svg', title: "総本数", value: "#{@total_count}" },
-      { icon: 'icons-cigarettes-pack.svg', title: "今日の本数", value: "#{@today_count}" }
-    ].each do |item| %>
-      <div class="bg-cardBackground p-4 rounded-lg shadow-lg transition duration-300 hover:shadow-xl flex items-center h-24">
-        <div class="flex items-center justify-between w-full">
-          <div class="flex items-center">
-            <%= inline_svg_tag item[:icon], class: "w-6 h-6 mr-2"%>
-            <span class="text-labelColor"><%= item[:title] %></span>
-          </div>
-          <div class="text-2xl font-bold text-white flex items-center">
-            <%= item[:value] %>
-            <% if item[:title].include?("本数") %>
-              <span class="text-labelColor text-sm ml-1">本</span>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    <% end %>
-  </div>
+  <!-- 統計情報 -->
+  <%= render 'statistics' %>
 
   <!-- 喫煙記録ログ -->
   <div class="bg-cardBackground rounded-lg p-6 shadow-lg">
-    <h2 class="text-2xl font-bold mb-4 flex items-center text-base-content">
+    <h2 class="text-2xl font-bold mb-4 flex items-center text-white">
       <i class="fas fa-clipboard-list mr-2"></i>
-      今日の喫煙記録ログ
+      喫煙記録ログ
     </h2>
     <div class="max-h-[calc(100vh-400px)] overflow-y-auto">
       <ul class="space-y-3">
-        <% @smoking_records.each do |log| %>
+        <% @paginated_records.each do |log| %>
           <li class="bg-itemBackground p-3 rounded-lg shadow transition duration-300 hover:bg-base-100">
             <div class="grid grid-cols-12 items-center gap-2">
-              <span class="text-base-content opacity-70 col-span-5 truncate"><%= log.smoked_at.strftime("%Y/%m/%d %H:%M") %></span>
-              <span class="font-medium text-base-content col-span-3 truncate"><%= log.brand_name %></span>
-              <span class="text-accent col-span-3 pl-4"><%= number_to_currency(log.price_per_cigarette) %></span>
+              <span class="text-white opacity-70 col-span-5 truncate"><%= log.smoked_at.strftime("%Y/%m/%d %H:%M") %></span>
+              <span class="font-medium text-white col-span-3 truncate"><%= log.brand_name %></span>
+              <span class="text-yellow-500 col-span-3 pl-4"><%= number_to_currency(log.price_per_cigarette) %></span>
               <div class="col-span-1 flex justify-end">
                 <%= button_to smoker_smoking_record_path(log), method: :delete, data: { turbo_confirm: "本当にこの記録を削除しますか？" }, class: "btn btn-ghost btn-xs" do %>
-                  <i class="fas fa-trash-alt text-error"></i>
+                  <i class="fas fa-trash-alt text-red-500"></i>
                 <% end %>
               </div>
             </div>
@@ -128,7 +39,7 @@
       </ul>
     </div>
     <div class="mt-4">
-      <%= paginate @smoking_records, window: 2 %>
+      <%= paginate @paginated_records, window: 2 %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### シンプルカレンダーの実装

- 現状のカレンダーをしにプルカレンダーを使う形変更
- 喫煙フォームと喫煙統計をテンプレートとして切り抜き