### PR TITLE
グラフページ作成

### DIFF
--- a/app/controllers/smoker/graphs_controller.rb
+++ b/app/controllers/smoker/graphs_controller.rb
@@ -1,21 +1,19 @@
 class Smoker::GraphsController < ApplicationController
   before_action :require_login
+  before_action :set_date_range
+
   def index
-    # 日、週、月、のデータを取得
-    @daily_smoking_count = smoking_records.group_by_day(:smoked_at, range: 30.days.ago..Time.current).count
-    @weekly_smoking_count = smoking_records.group_by_week(:smoked_at, range: 12.weeks.ago..Time.current).count
-    @monthly_smoking_count = smoking_records.group_by_month(:smoked_at, range: 12.months.ago..Time.current).count
-
-    # 喫煙時間
-    @hourly_smoking_count = smoking_records.group_by_hour_of_day(:smoked_at).count
-
-    # 銘柄の割合
-    @brand_smoking_count = smoking_records.group(:brand_name).count
+    @period = params[:period] || 'daily'
+    @daily_smoking_data = SmokingRecord.fetch_data(current_user, :day, @start_date, @end_date)
+    @weekly_smoking_data = SmokingRecord.fetch_data(current_user, :week, @start_date, @end_date)
+    @monthly_smoking_data = SmokingRecord.fetch_data(current_user, :month, @start_date, @end_date)
+    @hourly_smoking_data = SmokingRecord.fetch_hourly_data(current_user)
   end
 
   private
 
-  def current_smoking_record
-    current_user.smoking_records
+  def set_date_range
+    @end_date = Date.today
+    @start_date = @end_date - 6.days
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,20 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "chartkick/chart.js"
+import Chart from 'chart.js/auto'
+import ChartDataLabels from 'chartjs-plugin-datalabels'
+
+Chart.register(ChartDataLabels)
+
+Chart.defaults.set('plugins.datalabels', {
+  color: 'white',
+  backgroundColor: 'rgba(59, 130, 246, 0.7)',
+  borderRadius: 4,
+  font: {
+    weight: 'bold'
+  },
+  formatter: (value, ctx) => {
+    return value > 0 ? value : '';
+  },
+  display: (context) => context.dataset.data[context.dataIndex] > 0
+})

--- a/app/models/smoking_record.rb
+++ b/app/models/smoking_record.rb
@@ -11,6 +11,7 @@ class SmokingRecord < ApplicationRecord
   before_validation :set_smoked_at
 
   scope :today, -> { where(smoked_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day) }
+  scope :in_range, ->(range) { where(smoked_at: range.begin.beginning_of_day.in_time_zone('UTC')..range.end.end_of_day.in_time_zone('UTC')) }
 
   def self.total_amount
     sum(:price_per_cigarette)
@@ -25,11 +26,31 @@ class SmokingRecord < ApplicationRecord
   end
 
   def self.today_count
-    today.count
+    today.count 
   end
 
   def start_time
     smoked_at
+  end
+
+  # 指定された期間のデータを取得　(グラフ表示用)
+  def self.fetch_data(user, period, start_date, end_date)
+    range = date_range_for(period, start_date, end_date)
+    data = user.smoking_records.in_range(range)
+      .group_by_period(period, :smoked_at, time_zone: 'Tokyo', range: range)
+      .count
+    data
+  end
+  
+
+  # 時間帯ごとのデータを取得　(グラフ表示用)
+  def self.fetch_hourly_data(user)
+    data = user.smoking_records
+      .group_by_hour_of_day(:smoked_at, time_zone: 'Tokyo')
+      .count
+
+    (0..23).each { |hour| data[hour] ||= 0 }
+    data
   end
 
   private
@@ -44,5 +65,14 @@ class SmokingRecord < ApplicationRecord
 
   def set_smoked_at
     self.smoked_at ||= Time.current
+  end
+
+  # 指定された期間の範囲を返す (グラフ表示用)
+  def self.date_range_for(period, start_date, end_date)
+    case period
+    when :day then start_date..end_date
+    when :week then (end_date.end_of_week - 4.weeks)..end_date.end_of_week
+    when :month then (end_date.end_of_month - 5.months)..end_date.end_of_month
+    end
   end
 end

--- a/app/views/shared/_smoker_sidebar.html.erb
+++ b/app/views/shared/_smoker_sidebar.html.erb
@@ -50,7 +50,7 @@
             <span class="text-sm font-medium text-gray-300 transition-colors duration-200 ease-in-out group-hover:text-white">登録</span>
           </div>
         <% end %>
-        <%= link_to '#', class: "block py-1.5 mt-2 relative group" do %>
+        <%= link_to smoker_graphs_path, class: "block py-1.5 mt-2 relative group" do %>
           <div class="flex items-center space-x-2 transition-transform duration-200 ease-in-out group-hover:translate-x-1">
             <%= inline_svg 'icons-chart.svg', class: 'w-5 h-5 text-gray-300 transition-colors duration-200 ease-in-out group-hover:text-white' %>
             <span class="text-sm font-medium text-gray-300 transition-colors duration-200 ease-in-out group-hover:text-white">グラフ</span>

--- a/app/views/smoker/cigarettes/index.html.erb
+++ b/app/views/smoker/cigarettes/index.html.erb
@@ -1,4 +1,4 @@
-<div class="ml-36 pl-8 pt-24 min-h-screen bg-darkBackground">
+<div class="ml-32 pl-8 pt-24 min-h-screen bg-darkBackground">
   <div class="container mx-auto px-4">
     <h1 class="text-4xl font-light text-labelColor mb-8">タバコ管理</h1>
     

--- a/app/views/smoker/graphs/_period_chart.html.erb
+++ b/app/views/smoker/graphs/_period_chart.html.erb
@@ -1,0 +1,161 @@
+<% case @period %>
+<% when 'daily' %>
+  <% chart_max = (@daily_smoking_data.values.compact.max.to_f * 1.2).ceil %>
+  <h3 class="text-xl font-semibold mb-2">日別喫煙本数</h3>
+  <%= line_chart @daily_smoking_data, 
+      xtitle: '', 
+      ytitle: '', 
+      colors: ["#3b82f6"],
+      min: 0,
+      max: chart_max,
+      points: true,
+      curve: false,
+      library: {
+        layout: {
+          padding: {
+            top: 20
+          }
+        },
+        plugins: {
+          datalabels: {
+            anchor: 'end',
+            align: 'top',
+            formatter: ->(value) { value.to_i.to_s },
+            display: true
+          }
+        },
+        scales: {
+          x: {
+            type: 'time',
+            time: {
+              unit: 'day',
+              parser: 'yyyy-MM-dd',
+              tooltipFormat: 'yyyy/MM/dd',
+              displayFormats: {
+                day: 'M/d'
+              }
+            },
+            ticks: {
+              source: 'data',
+              autoSkip: false
+            }
+          },
+          y: {
+            beginAtZero: true,
+            ticks: {
+              stepSize: 1
+            }
+          }
+        }
+      },
+      dataset: { 
+        spanGaps: false 
+      }
+  %>
+<% when 'weekly' %>
+  <% chart_max = (@weekly_smoking_data.values.compact.max.to_f * 1.2).ceil %>
+  <h3 class="text-xl font-semibold mb-2">週別喫煙本数</h3>
+  <%= line_chart @weekly_smoking_data, 
+      xtitle: '', 
+      ytitle: '', 
+      colors: ["#3b82f6"],
+      min: 0,
+      max: chart_max,
+      points: true,
+      curve: false,
+      library: {
+        layout: {
+          padding: {
+            top: 20
+          }
+        },
+        plugins: {
+          datalabels: {
+            anchor: 'end',
+            align: 'top',
+            formatter: ->(value) { value.to_i.to_s },
+            display: true
+          }
+        },
+        scales: {
+          x: {
+            type: 'time',
+            time: {
+              unit: 'week',
+              parser: 'yyyy-MM-dd',
+              tooltipFormat: 'yyyy/MM/dd',
+              displayFormats: {
+                week: 'yyyy/MM/dd'
+              }
+            },
+            ticks: {
+              source: 'data',
+              autoSkip: false
+            }
+          },
+          y: {
+            beginAtZero: true,
+            ticks: {
+              stepSize: 1
+            }
+          }
+        }
+      },
+      dataset: { 
+        spanGaps: false 
+      }
+  %>
+<% when 'monthly' %>
+  <% chart_max = (@monthly_smoking_data.values.compact.max.to_f * 1.2).ceil %>
+  <h3 class="text-xl font-semibold mb-2">月別喫煙本数</h3>
+  <%= line_chart @monthly_smoking_data, 
+      xtitle: '', 
+      ytitle: '', 
+      colors: ["#3b82f6"],
+      min: 0,
+      max: chart_max,
+      points: true,
+      curve: false,
+      library: {
+        layout: {
+          padding: {
+            top: 20
+          }
+        },
+        plugins: {
+          datalabels: {
+            anchor: 'end',
+            align: 'top',
+            formatter: ->(value) { value.to_i.to_s },
+            display: true
+          }
+        },
+        scales: {
+          x: {
+            type: 'time',
+            time: {
+              unit: 'month',
+              parser: 'yyyy-MM-dd',
+              tooltipFormat: 'yyyy/MM',
+              displayFormats: {
+                month: 'yyyy/MM'
+              }
+            },
+            ticks: {
+              source: 'data',
+              autoSkip: false
+            }
+          },
+          y: {
+            beginAtZero: true,
+            ticks: {
+              stepSize: 1
+            }
+          }
+        }
+      },
+      dataset: { 
+        spanGaps: false 
+      }
+  %>
+<% end %>

--- a/app/views/smoker/graphs/index.html.erb
+++ b/app/views/smoker/graphs/index.html.erb
@@ -1,2 +1,72 @@
-<h1>Smoker::Graphs#index</h1>
-<p>Find me in app/views/smoker/graphs/index.html.erb</p>
+<div class="container mx-auto px-4 py-8 pt-24 ml-32">
+  <h1 class="text-3xl font-bold mb-8 flex items-center">
+    <%= inline_svg_tag 'icons-chart.svg', class: 'w-8 h-8 mr-3' %>
+    喫煙グラフ
+  </h1>
+
+  <div class="space-y-8">
+    <div class="card bg-cardBackground shadow-xl border border-gray-700">
+      <div class="card-body p-4">
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="card-title text-xl flex items-center">
+            <%= inline_svg_tag 'icons-calendar.svg', class: 'w-6 h-6 mr-2' %>
+            期間別喫煙本数
+          </h2>
+          <div class="btn-group space-x-2">
+            <%= link_to smoker_graphs_path(period: 'daily'), class: "px-4 py-2 bg-secondaryButton text-white rounded-md hover:bg-secondaryButtonHover transition duration-300 #{params[:period] == 'daily' ? 'btn-active' : ''}", data: { turbo_frame: 'period_chart' } do %>
+              <i class="fas fa-calendar-day mr-1"></i> 日別
+            <% end %>
+            <%= link_to smoker_graphs_path(period: 'weekly'), class: "px-4 py-2 bg-secondaryButton text-white rounded-md hover:bg-secondaryButtonHover transition duration-300 #{params[:period] == 'weekly' ? 'btn-active' : ''}", data: { turbo_frame: 'period_chart' } do %>
+              <i class="fas fa-calendar-week mr-1"></i> 週別
+            <% end %>
+            <%= link_to smoker_graphs_path(period: 'monthly'), class: "px-4 py-2 bg-secondaryButton text-white rounded-md hover:bg-secondaryButtonHover transition duration-300 #{params[:period] == 'monthly' ? 'btn-active' : ''}", data: { turbo_frame: 'period_chart' } do %>
+              <i class="fas fa-calendar-alt mr-1"></i> 月別
+            <% end %>
+          </div>
+        </div>
+        <div style="height: 400px;" class="bg-itemBackground rounded-lg p-4">
+          <%= turbo_frame_tag "period_chart" do %>
+            <%= render 'period_chart', period: params[:period] || 'daily' %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="card bg-cardBackground shadow-xl border border-gray-700">
+      <div class="card-body p-4">
+        <h2 class="card-title text-xl mb-4 flex items-center">
+          <%= inline_svg_tag 'icons-clock.svg', class: 'w-6 h-6 mr-2' %>
+          時間帯別喫煙本数
+        </h2>
+        <div style="height: 400px;" class="bg-itemBackground rounded-lg p-4">
+          <% max_hourly_value = @hourly_smoking_data.values.max %>
+          <% chart_max = (max_hourly_value * 1.2).ceil %>
+          <%= column_chart @hourly_smoking_data, 
+              xtitle: '', 
+              ytitle: '', 
+              colors: ["#3b82f6"], 
+              height: "100%",
+              min: 0,
+              max: chart_max,
+              library: {
+                plugins: {
+                  datalabels: {
+                    anchor: 'end',
+                    align: 'top'
+                  }
+                },
+                scales: {
+                  y: {
+                    beginAtZero: true,
+                    ticks: {
+                      stepSize: 1
+                    }
+                  }
+                }
+              }
+          %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module Myapp
     # config.time_zone = "Central Time (US & Canada)"
 
     config.time_zone = 'Tokyo'   # タイムゾーンを日本時間に設定
-    config.active_record.default_timezone = :local   # DBのタイムゾーンをローカルタイムに設定
+    config.active_record.default_timezone = :utc  # groupdateを使っているのでutcに設定
 
     # config.eager_load_paths << Rails.root.join("extras")
     config.generators do |g|

--- a/config/initializers/groupdate.rb
+++ b/config/initializers/groupdate.rb
@@ -1,0 +1,1 @@
+Groupdate.time_zone = "Tokyo"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,11 +12,14 @@ Rails.application.routes.draw do
   resources :users, only: [:new, :create]
 
   namespace :smoker do
+    resources :graphs, only: [:index]
+
     resources :cigarettes, only: [:index, :create, :edit, :update] do
       collection do
         get :brands
       end
     end
+
     resources :smoking_records, only: [:index, :create, :destroy]
   end
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@hotwired/turbo-rails": "^8.0.5",
     "autoprefixer": "^10.4.20",
     "chart.js": "^4.4.4",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "chartkick": "^5.0.1",
     "daisyui": "^4.12.10",
     "postcss": "^8.4.41",

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,6 +333,11 @@ chartjs-adapter-date-fns@>=3:
   resolved "https://registry.yarnpkg.com/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz#c25f63c7f317c1f96f9a7c44bd45eeedb8a478e5"
   integrity sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==
 
+chartjs-plugin-datalabels@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz#369578e131d743c2e34b5fbe2d3f9335f6639b8f"
+  integrity sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==
+
 chartkick@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-5.0.1.tgz#f557ff8560f974343dc65c7fc34ce1e8326d8ee7"


### PR DESCRIPTION
## グラフ機能の追加

### 1. グラフの追加

- 時間帯別喫煙本数の棒グラフを追加

- 日別、週別、月別の喫煙本数を表示する折れ線グラフを追加

- Turboを使用して非同期でグラフを切り替える機能を実装（折れ線グラフのみ）

### 2. ライブラリの追加

- Chart.js: グラフ描画のメインライブラリ
  ```javascript
  import Chart from 'chart.js/auto'

-   グラフにデータラベルを表示するプラグインの追加

### 3. モデルの拡張

- fetch_data: 指定された期間のデータを取得

- fetch_hourly_data: 時間帯ごとのデータを取得

### 4. タイムゾーン設定の調整

- データベースのタイムゾーンをUTCに設定（groupdate gemの使用に対応）

- Groupdate gem のタイムゾーンを 'Tokyo' に設定