### PR TITLE
パスワードリセット事前準備

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,13 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.reset_password_email.subject
+  #
+  def reset_password_email
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 8 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+  validates :reset_password_token, uniqueness: true, allow_nil: true
 
   validates :name, presence: true, length: { maximum: 10 }
   validates :email, presence: true, uniqueness: true

--- a/app/views/user_mailer/reset_password_email.html.erb
+++ b/app/views/user_mailer/reset_password_email.html.erb
@@ -1,0 +1,5 @@
+<h1>User#reset_password_email</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/reset_password_email.html.erb
+</p>

--- a/app/views/user_mailer/reset_password_email.text.erb
+++ b/app/views/user_mailer/reset_password_email.text.erb
@@ -1,0 +1,3 @@
+User#reset_password_email
+
+<%= @greeting %>, find me in app/views/user_mailer/reset_password_email.text.erb

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:external]
+Rails.application.config.sorcery.submodules = [:external, :reset_password]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -400,7 +400,7 @@ Rails.application.config.sorcery.configure do |config|
     # Password reset mailer class.
     # Default: `nil`
     #
-    # user.reset_password_mailer =
+    user.reset_password_mailer = UserMailer
 
     # Reset password email method on your mailer class.
     # Default: `:reset_password_email`

--- a/db/migrate/20241101143617_sorcery_reset_password.rb
+++ b/db/migrate/20241101143617_sorcery_reset_password.rb
@@ -1,0 +1,10 @@
+class SorceryResetPassword < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :reset_password_token, :string, default: nil
+    add_column :users, :reset_password_token_expires_at, :datetime, default: nil
+    add_column :users, :reset_password_email_sent_at, :datetime, default: nil
+    add_column :users, :access_count_to_reset_password_page, :integer, default: 0
+
+    add_index :users, :reset_password_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_30_124459) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_01_143617) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -87,7 +87,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_30_124459) do
     t.datetime "updated_at", null: false
     t.string "name", null: false
     t.integer "smoking_status", default: 0, null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_token_expires_at"
+    t.datetime "reset_password_email_sent_at"
+    t.integer "access_count_to_reset_password_page", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
   add_foreign_key "cigarettes", "users"


### PR DESCRIPTION
## サブモジュールの追加

```
rails g sorcery:install reset_password --only-submodules
```

上記を実行し、作成されたDBをmigrate

## 基本設定

- reset_password サブモジュールを追加し、使用するメーラーを定義します。

## パスワードリセット用のメイラーの作成

```
rails g mailer UserMailer reset_password_email
```

上記を実行した。中身はまだ書いていない。

## userモデル

- トークンの文字列が重複しないようにユニーク制約をかける。ただし、allow_nilオプションでnilの重複については許容できるようにしている

