### PR TITLE
平均金額計算ロジック修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,15 +20,13 @@ class User < ApplicationRecord
 
   def calculate_daily_potential_savings
     return 0 if smoking_records.empty?
-    total_spent = smoking_records.sum(:price_per_cigarette)
-    total_days = (smoking_records.maximum(:smoked_at).to_date - smoking_records.minimum(:smoked_at).to_date).to_i + 1
-    (total_spent / total_days).round(2)
-  end
 
-  def average_daily_cigarettes
-    return 0 if smoking_records.empty?
-    total_days = (smoking_records.maximum(:smoked_at).to_date - smoking_records.minimum(:smoked_at).to_date).to_i + 1
-    (smoking_records.count.to_f / total_days).round(2)
+    # 喫煙した日ごとにグループ化して日数を数える
+    smoking_days = smoking_records.group('DATE(smoked_at)').count.size
+
+    # 総喫煙金額を喫煙日数で割る
+    total_spent = smoking_records.sum(:price_per_cigarette)
+    (total_spent.to_f / smoking_days).round(2)
   end
 
   def analyze_danger_hours


### PR DESCRIPTION
# 禁煙記録の節約額計算方法の改善

## 現状の問題点

### 1. 1日の節約金額が禁煙期間中に変化する問題
現在の計算方法では、禁煙期間中であっても1日あたりの節約金額が変動してしまう。

**現在の実装**
```ruby
def calculate_daily_potential_savings
  return 0 if smoking_records.empty?
  total_spent = smoking_records.sum(:price_per_cigarette)
  total_days = (smoking_records.maximum(:smoked_at).to_date - smoking_records.minimum(:smoked_at).to_date).to_i + 1
  (total_spent / total_days).round(2)
end
```

この方法だと、禁煙中の日数も含まれてしまうため実際のコストより低く見積もってしまう

現状だと、

```
全期間の喫煙記録の合計金額   ÷  最初の喫煙から最後の喫煙までの日数
```

の計算方式だが 

 ```
 全期間の喫煙記録の合計金額　÷  全期間の喫煙した日の記録
```
このように変更した。
