### PR TITLE
デプロイエラー修正

### DIFF
--- a/db/migrate/20241106211908_add_daily_smoking_amount_to_quit_smoking_records.rb
+++ b/db/migrate/20241106211908_add_daily_smoking_amount_to_quit_smoking_records.rb
@@ -1,5 +1,5 @@
 class AddDailySmokingAmountToQuitSmokingRecords < ActiveRecord::Migration[7.1]
   def change
-    add_column :quit_smoking_records, :daily_smoking_amount, :integer, null: false
+    add_column :quit_smoking_records, :daily_smoking_amount, :integer, null: false, default: 0
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,7 +49,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_06_211908) do
     t.datetime "end_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "daily_smoking_amount", null: false
+    t.integer "daily_smoking_amount", default: 0, null: false
     t.index ["user_id"], name: "index_quit_smoking_records_on_user_id"
   end
 


### PR DESCRIPTION
## デプロイエラーの修正

既存のレコードにNULL値が含まれているため失敗しているためデフォルト値を0としてつけた

修正してから気づいたが開発段階なので本番環境側でリセットをかければよかった。