### PR TITLE
デプロイエラーのための修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ module ApplicationHelper
       charset: 'utf-8',
       description: '実際の喫煙データがあるからこそ、その時の自分に合った禁煙プランを。短期の節約目的から完全な禁煙まで、あなたのペースで',
       keywords: '禁煙,禁煙アプリ,禁煙サポート,節約,喫煙記録',
-      canonical: `https://smokeshift.onrender.com`,
+      canonical: request.original_url,
       separator: '|',
       og:{
         site_name: :site,
@@ -24,7 +24,7 @@ module ApplicationHelper
         description: :description,
         type: 'website',
         url: request.original_url,
-        image: 'https://smokeshift.onrender.com',
+        image: request.original_url,
         local: 'ja-JP'
       },
       twitter: {


### PR DESCRIPTION
## デプロイエラー修正

### エラー部分

`canonical:` `'https://smokeshift.onrender.com'`
`image:` `'https://smokeshift.onrender.com'`

を

`canonical: request.original_url`
`image: request.original_url`

のように修正
直接urlを書き込むところではないらしい。
