### PR TITLE
email整形の削除

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -36,9 +36,7 @@ class OauthsController < ApplicationController
   end
 
   def create_user_from_provider(provider)
-    create_from(provider) do |user|
-      user.email = "line_#{user.email}@example.com" if provider == 'line'
-    end
+    create_from(provider)
   rescue StandardError => e
     Rails.logger.error "Login error: #{e.message}"
     nil


### PR DESCRIPTION
## LINEログイン修正

### emailの削除

- LINE登録の際マッピングされたuidを`uid@example.com`の形に整形していたが不要と判断してので削除