### PR TITLE
トップページのボタン遷移改善

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,6 +32,21 @@ module ApplicationHelper
   end
   # rubocop:enable Metrics/MethodLength
 
+  # topページのボタン遷移
+  def start_button_path
+    def start_button_path
+      if logged_in?
+        if current_user.smoking_status == "smoker"
+          smoker_smoking_records_path
+        else
+          non_smoker_quit_smoking_records_path # 修正: ネームスペースを追加
+        end
+      else
+        new_user_path
+      end
+    end
+  end
+
   # 禁煙記録の期間をフォーマット
   def format_duration(input, end_time = nil)
     seconds = calculate_seconds(input, end_time)

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -26,7 +26,7 @@
             記録を始めるなら、今日から。禁煙を始めるなら、あなたの決めたタイミングで。<br>
             実際の喫煙データがあるからこそ、その時の自分に合った禁煙プランを。
           </p>
-          <%= link_to "はじめる", new_user_path, class: "btn btn-primary btn-lg text-lg font-semibold tracking-wide" %>
+          <%= link_to "はじめる", start_button_path, class: "btn btn-primary btn-lg text-lg font-semibold tracking-wide" %>
         </div>
       </div>
     </div>
@@ -155,7 +155,16 @@
           今は記録するだけでOK。<br>
           禁煙を決意したその時のために、あなたの大切なデータを蓄積していきます。
         </p>
-        <%= link_to "アカウントを作成", new_user_path, class: "btn btn-primary btn-lg text-lg font-semibold tracking-wide" %>
+        <% if logged_in? %>
+          <p class="text-gray-300 text-lg mb-4">
+            既にログインしています。記録画面や統計情報を確認しましょう。
+          </p>
+        <% else %>
+          <p class="text-gray-300 text-lg mb-4">
+            アカウントを作成して禁煙記録を始めましょう。
+          </p>
+          <%= link_to "アカウントを作成", new_user_path, class: "btn btn-primary btn-lg text-lg font-semibold tracking-wide" %>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## ボタンナビゲーションの改善

### 問題点

1. ログインしている状態で「はじめる」ボタンを押すと新規登録画面に遷移する
2. ログインしている状態で「まずは記録から始めましょう」の部分の「アカウントを作成」ボタンを押すと新規登録画面に遷移する

## 修正内容

### 「はじめる」ボタン

- helperにログイン状態の有無、ユーザーの喫煙状態に応じて遷移先を決めるロジックを追加
- topページ側でhlperに追加したメソッドを使い始めるボタンを更新

### 「アカウント作成」ボタン

- ログイン状態の有無を確認し、ログインしている場合ボタンを非表示にしテキスト文を追加。